### PR TITLE
Add Insert key support

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -88,6 +88,7 @@ const (
 	KeyF11
 	KeyF12
 	KeyBack
+	KeyInsert
 )
 
 // KeyCombo is a key together with the modifier keys held with it — the unit

--- a/waylandbackend/waylandkeyboard_linux.go
+++ b/waylandbackend/waylandkeyboard_linux.go
@@ -240,6 +240,8 @@ func mapKeysym(ks uint32) shirei.KeyCode {
 		return shirei.KeyHome
 	case xkEnd:
 		return shirei.KeyEnd
+	case xkb.KeyInsert:
+		return shirei.KeyInsert
 	case xkPrior:
 		return shirei.KeyPageUp
 	case xkNext:

--- a/win32backend/win32api_windows.go
+++ b/win32backend/win32api_windows.go
@@ -184,6 +184,7 @@ const (
 	vkUp         = 0x26
 	vkRight      = 0x27
 	vkDown       = 0x28
+	vkInsert     = 0x2D
 	vkDelete     = 0x2E
 	vkLwin       = 0x5B
 	vkRwin       = 0x5C

--- a/win32backend/win32backend_windows.go
+++ b/win32backend/win32backend_windows.go
@@ -826,6 +826,8 @@ func mapVKey(vk uint32) shirei.KeyCode {
 		return shirei.KeyHome
 	case vkEnd:
 		return shirei.KeyEnd
+	case vkInsert:
+		return shirei.KeyInsert
 	case vkPrior:
 		return shirei.KeyPageUp
 	case vkNext:

--- a/x11backend/x11input.go
+++ b/x11backend/x11input.go
@@ -275,6 +275,7 @@ const (
 	xkPrior     = 0xff55 // Page Up
 	xkNext      = 0xff56 // Page Down
 	xkEnd       = 0xff57
+	xkInsert    = 0xff63
 	xkDelete    = 0xffff
 	xkSpace     = 0x0020
 	xkF1        = 0xffbe
@@ -303,6 +304,8 @@ func mapKeysym(ks xproto.Keysym) shirei.KeyCode {
 		return shirei.KeyHome
 	case xkEnd:
 		return shirei.KeyEnd
+	case xkInsert:
+		return shirei.KeyInsert
 	case xkPrior:
 		return shirei.KeyPageUp
 	case xkNext:


### PR DESCRIPTION
Adds a physical `KeyInsert` code without changing existing key-code values.

Maps the native Insert key in the Windows, X11, and Wayland desktop backends. Cocoa and mobile backends are unchanged.