### PR TITLE
Upgrade golang.org/x/image to v0.43.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/jezek/xgb v1.1.1
 	go.hasen.dev/generic v0.1.6
-	golang.org/x/image v0.29.0
+	golang.org/x/image v0.43.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.38.0
 )

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.hasen.dev/generic v0.1.6 h1:byxEKkq8p6g7bp37pL40Ual7P4qtI7UN5wBoiNg97rM=
 go.hasen.dev/generic v0.1.6/go.mod h1:SB5p5H5YYQHnqjSFHXW89C6iH6qF/669p4640DPWGbA=
-golang.org/x/image v0.29.0 h1:HcdsyR4Gsuys/Axh0rDEmlBmB68rW1U9BUdB3UVHsas=
-golang.org/x/image v0.29.0/go.mod h1:RVJROnf3SLK8d26OW91j4FrIHGbsJ8QnbEocVTOWQDA=
+golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
+golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=


### PR DESCRIPTION
## Summary

Upgrade the direct `golang.org/x/image` dependency from `v0.29.0` to `v0.43.0`.

This is a security update. Upgrading to `v0.43.0` removes reachable vulnerabilities reported against `x/image v0.29.0`.

The affected version is covered by the following Go vulnerability reports:

- [GO-2026-5066](https://pkg.go.dev/vuln/GO-2026-5066)
- [GO-2026-5062](https://pkg.go.dev/vuln/GO-2026-5062)
- [GO-2026-5061](https://pkg.go.dev/vuln/GO-2026-5061)
- [GO-2026-5032](https://pkg.go.dev/vuln/GO-2026-5032)
- [GO-2026-4961](https://pkg.go.dev/vuln/GO-2026-4961)
- [GO-2026-4815](https://pkg.go.dev/vuln/GO-2026-4815)

## Validation

- `go mod tidy`
- `go vet ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
  - No reachable vulnerabilities found
- `go test ./...`
  - The repository's known environment-sensitive font/render and snapshot tests fail in this Linux environment; unrelated packages pass
