### PR TITLE
Fix Tab crash with no focusable controls

### DIFF
--- a/focus_test.go
+++ b/focus_test.go
@@ -1,0 +1,28 @@
+package shirei
+
+import "testing"
+
+func TestRunFrameTabWithNoFocusableControls(t *testing.T) {
+	tests := []struct {
+		name      string
+		modifiers Modifiers
+	}{
+		{name: "Tab"},
+		{name: "Shift+Tab", modifiers: ModShift},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetInputSession()
+			RunFrameFn(func() {}) // establish an empty previous frame
+
+			ui.Host.Input.Modifiers = tt.modifiers
+			ui.Host.FrameInput.Key = KeyTab
+			RunFrameFn(func() {})
+
+			if ui.nextFocused != nil {
+				t.Fatal("Tab with no focusable controls scheduled focus")
+			}
+		})
+	}
+}

--- a/shirei.go
+++ b/shirei.go
@@ -1587,6 +1587,10 @@ func stealFocusOnMount() {
 
 // dir should be 1 or -1, but an arbitrary number should work too ..
 func cycleFocus(dir int) {
+	if len(ui.focusables) == 0 {
+		return
+	}
+
 	idx := slices.Index(ui.focusables, ui.focused)
 	if idx == -1 {
 		// special case


### PR DESCRIPTION
## Problem

Pressing Tab or Shift+Tab when the previous frame contains no focusable controls causes a divide-by-zero panic in `cycleFocus`.

`RunFrameFn` performs automatic Tab focus cycling before invoking the application's frame callback. When `ui.focusables` is empty, `cycleFocus` calculates the next index using modulo zero.

## Fix

Make `cycleFocus` return early when there are no focusable controls. Keeping the defensive check at this core boundary protects both automatic frame-level Tab handling and explicit `CycleFocusOnTab` use without changing normal focus traversal behavior.

Add regression coverage that exercises `RunFrameFn` with an empty previous frame and verifies that both Tab and Shift+Tab are safe no-ops and do not schedule focus.
