### PR TITLE
Fix/wayland resize redraw

### DIFF
--- a/waylandbackend/waylandbackend_linux.go
+++ b/waylandbackend/waylandbackend_linux.go
@@ -294,20 +294,28 @@ func createWindow() {
 	perfLog("[wl] window created; committed, awaiting first configure")
 }
 
-// HandleSurfaceConfigure ends the configure sequence: apply the staged size and
-// ask for a frame — an interactive resize holds a pointer grab, so no input
-// event sets `dirty`. The ack rides with that frame (see drawFrame).
+// HandleSurfaceConfigure ends the configure sequence. On a size change apply
+// the staged size and ask for a frame — an interactive resize holds a pointer
+// grab, so no input event sets `dirty`; the ack rides with that frame (see
+// drawFrame). A state-only configure (focus flip, tiling toggle at the same
+// size) needs no redraw, so it is acked on arrival instead.
 func (*handler) HandleSurfaceConfigure(ev zxdg.SurfaceConfigureEvent) {
-	if pendingW > 0 && pendingH > 0 && (pendingW != logicalW || pendingH != logicalH) {
+	resized := pendingW > 0 && pendingH > 0 && (pendingW != logicalW || pendingH != logicalH)
+	if resized {
 		logicalW, logicalH = pendingW, pendingH
 		recomputeDeviceSize()
 	}
+	pendingW, pendingH = 0, 0 // consume the staged size; a bare configure must not re-apply it
+	if !resized && !waitConfigure && !hasAck {
+		xdgSurface.AckConfigure(ev.Serial)
+		return
+	}
+	// A deferred ack may already be in flight; only the newest serial needs acking.
 	ackSerial, hasAck = ev.Serial, true
 	dirty = true
 	if waitConfigure {
 		waitConfigure = false
-		perfLog("[wl] first configure; drawing first frame")
-		drawFrame()
+		perfLog("[wl] first configure; first frame follows this dispatch")
 	}
 }
 

--- a/waylandbackend/waylandbackend_linux.go
+++ b/waylandbackend/waylandbackend_linux.go
@@ -39,8 +39,12 @@ var (
 	xdgToplevel *zxdg.Toplevel
 
 	logicalW, logicalH int         // surface (logical) size, in points
+	pendingW, pendingH int         // size staged by xdg_toplevel.configure
 	curW, curH         int         // device-pixel buffer size = logical * scale
 	windowScale        float32 = 1 // device px per logical point (wl_output scale)
+
+	ackSerial uint32 // acked in drawFrame, not on arrival
+	hasAck    bool
 
 	seat          *wl.Seat
 	pointer       *wl.Pointer
@@ -290,25 +294,29 @@ func createWindow() {
 	perfLog("[wl] window created; committed, awaiting first configure")
 }
 
-// HandleSurfaceConfigure: ack the configure and, on the first one, kick off
-// rendering.
+// HandleSurfaceConfigure ends the configure sequence: apply the staged size and
+// ask for a frame — an interactive resize holds a pointer grab, so no input
+// event sets `dirty`. The ack rides with that frame (see drawFrame).
 func (*handler) HandleSurfaceConfigure(ev zxdg.SurfaceConfigureEvent) {
-	xdgSurface.AckConfigure(ev.Serial)
+	if pendingW > 0 && pendingH > 0 && (pendingW != logicalW || pendingH != logicalH) {
+		logicalW, logicalH = pendingW, pendingH
+		recomputeDeviceSize()
+	}
+	ackSerial, hasAck = ev.Serial, true
+	dirty = true
 	if waitConfigure {
 		waitConfigure = false
-		perfLog("[wl] first configure acked; drawing first frame")
+		perfLog("[wl] first configure; drawing first frame")
 		drawFrame()
 	}
 }
 
-// HandleToplevelConfigure carries the compositor's requested size (0 = client
-// chooses). On a real size change we adopt it; buffers are recreated lazily.
+// HandleToplevelConfigure only stages the size (0 = client chooses): the two
+// configure events can land in separate dispatch batches, so applying it here
+// would let a frame commit the new size under the previous ack.
 func (*handler) HandleToplevelConfigure(ev zxdg.ToplevelConfigureEvent) {
 	// Configure sizes are in logical points; the device buffer is scale times that.
-	if ev.Width > 0 && ev.Height > 0 && (int(ev.Width) != logicalW || int(ev.Height) != logicalH) {
-		logicalW, logicalH = int(ev.Width), int(ev.Height)
-		recomputeDeviceSize()
-	}
+	pendingW, pendingH = int(ev.Width), int(ev.Height)
 }
 
 func (*handler) HandleToplevelClose(zxdg.ToplevelCloseEvent) { quit = true }
@@ -444,6 +452,12 @@ func drawFrame() {
 
 	t1 := time.Now()
 	softRenderer.RenderInto(b.data, curW*4, curW, curH, scale, out.Surfaces)
+	// Ack before the attach: niri keys its resize animation off the acked serial,
+	// and skips it for a new size committed under an older ack.
+	if hasAck {
+		xdgSurface.AckConfigure(ackSerial)
+		hasAck = false
+	}
 	surface.Attach(b.buf, 0, 0)
 	surface.Damage(0, 0, int32(logicalW), int32(logicalH)) // damage is in surface (logical) coords
 


### PR DESCRIPTION
## What

Two bugs made window resizing look broken on niri, a Wayland compositor. The window froze for a moment, then snapped to its new size with no animation.

**The backend never asked for a redraw when the size changed.** A resize with the mouse holds a pointer grab, so no input event arrives to trigger one either. The window kept showing the old frame until something unrelated woke the event loop.

**The backend acknowledged the resize on arrival, not with the frame that answers it.** The compositor announces a resize in two events, and they can arrive in separate dispatch rounds. A frame could therefore go out carrying the new size but the previous acknowledgement. niri matches a resize to its acknowledgement to decide when to animate, so it never saw the resize and skipped the animation.

## The fix

The new size now takes effect on the event that ends the resize sequence, which is where the protocol says it applies. The acknowledgement moved next to the frame that answers it.

## How tested

I traced the backend on niri and resized the window over niri's IPC. The delay between the compositor asking for a size and the client answering dropped from 840 ms at worst to 38-53 ms. niri animates the resize again.

The image snapshot tests fail on my machine with and without this change, so they are unrelated.